### PR TITLE
Fixing invalid output directory path for run-multiple (#1117)

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -10,6 +10,7 @@ const path = require('path');
 const runHook = require('../hooks');
 const event = require('../event');
 const collection = require('./run-multiple/collection');
+const clearString = require('../utils').clearString;
 
 const runner = path.join(__dirname, '/../../bin/codecept');
 let config;
@@ -104,6 +105,8 @@ function executeRun(runName, runConfig) {
     outputDir += JSON.stringify(browserConfig).replace(/[^\d\w]+/g, '_');
   }
   outputDir += `_${runId}`;
+
+  outputDir = clearString(outputDir);
 
   // tweaking default output directories and for mochawesome
   overriddenConfig = replaceValue(overriddenConfig, 'output', path.join(config.output, outputDir));


### PR DESCRIPTION
* Scrubbing output directory path string of invalid characters.  This is to address Github issues #1084 and #1111.

* Scrubbing output directory path string of invalid characters.  This is to address Github issues #1084 and #1111.